### PR TITLE
Limit yield

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -188,11 +188,14 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
       );
     };
 
-    while (events.length || active) {
+    let limit  = options.limit ? options.limit : true;
+    let countEvents = 0
+
+    while ((events.length || active) && limit) {
       if (error) {
         throw error;
       }
-      while (events.length > 0) {
+      while (events.length > 0 && limit) {
         /* We do not want to block the process!
             This call allows other processes
             a chance to execute.
@@ -202,6 +205,10 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
         events = rest;
         
         yield options.transform ? options.transform(event) : event;
+        countEvents++
+        if(countEvents === limit) {
+          limit = false;
+        }
       }
 
       if (active && !error) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,14 +188,14 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
       );
     };
 
-    let limit = options.limit ? !!options.limit : true;
+    let shouldMakeYield = true;
     let countEvents = 0;
 
-    while ((events.length || active) && limit) {
+    while ((events.length || active) && shouldMakeYield) {
       if (error) {
         throw error;
       }
-      while (events.length > 0 && limit) {
+      while (events.length > 0 && shouldMakeYield) {
         /* We do not want to block the process!
             This call allows other processes
             a chance to execute.
@@ -207,7 +207,7 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
         yield options.transform ? options.transform(event) : event;
         countEvents++
         if(countEvents === options.limit) {
-          limit = false;
+          shouldMakeYield = false;
         }
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,8 +188,8 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
       );
     };
 
-    let limit  = options.limit ? options.limit : true;
-    let countEvents = 0
+    let limit = options.limit ? !!options.limit : true;
+    let countEvents = 0;
 
     while ((events.length || active) && limit) {
       if (error) {
@@ -206,7 +206,7 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
         
         yield options.transform ? options.transform(event) : event;
         countEvents++
-        if(countEvents === limit) {
+        if(countEvents === options.limit) {
           limit = false;
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -206,7 +206,7 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
         
         yield options.transform ? options.transform(event) : event;
         countEvents++
-        if(countEvents === options.limit) {
+        if(options.limit && countEvents >= options.limit) {
           shouldYield = false;
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,14 +188,14 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
       );
     };
 
-    let shouldMakeYield = true;
+    let shouldYield = true;
     let countEvents = 0;
 
-    while ((events.length || active) && shouldMakeYield) {
+    while (shouldYield && (events.length || active)) {
       if (error) {
         throw error;
       }
-      while (events.length > 0 && shouldMakeYield) {
+      while (shouldYield && events.length > 0) {
         /* We do not want to block the process!
             This call allows other processes
             a chance to execute.
@@ -207,7 +207,7 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
         yield options.transform ? options.transform(event) : event;
         countEvents++
         if(countEvents === options.limit) {
-          shouldMakeYield = false;
+          shouldYield = false;
         }
       }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -412,7 +412,7 @@ describe("forEmitOf", () => {
       expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] ")
     });
 
-    it.only("should make all interactions if the value of limit is 0 ", async () => {
+    it("should make all interactions if the value of limit is 0 ", async () => {
       const emitter = new EventEmitter();
 
       const iterator = forEmitOf<{ message: string }>(emitter, { limit: 0 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -380,7 +380,7 @@ describe("forEmitOf", () => {
       expect(result).to.equal("[false] [0] [] [not empty] ");
     });
 
-    it("should the number of interactions respect the limit even if the number of events is higher", async () => {
+    it("should the number of iterations respect the limit even if the number of events is higher", async () => {
       const emitter = new EventEmitter();
 
       const iterator = forEmitOf<{ message: string }>(emitter, { limit: 10 });
@@ -412,7 +412,7 @@ describe("forEmitOf", () => {
       expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] ")
     });
 
-    it("should make all interactions if the value of limit is 0 ", async () => {
+    it("should make all iterations if the value of limit is 0 ", async () => {
       const emitter = new EventEmitter();
 
       const iterator = forEmitOf<{ message: string }>(emitter, { limit: 0 });
@@ -444,7 +444,7 @@ describe("forEmitOf", () => {
       expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] [not empty 7] ")
     });
 
-    it("should the number of interactions respect the limit even if the number of events is higher", async () => {
+    it("should the number of iterations respect the limit even if the number of events is higher", async () => {
       const emitter = new EventEmitter();
 
       const iterator = forEmitOf<{ message: string }>(emitter, { limit: 10 });
@@ -476,7 +476,7 @@ describe("forEmitOf", () => {
       expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] ")
     });
 
-    it("should make all interactions if has no limit ", async () => {
+    it("should make all iterations if has no limit ", async () => {
       const emitter = new EventEmitter();
 
       const iterator = forEmitOf<{ message: string }>(emitter);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -380,7 +380,7 @@ describe("forEmitOf", () => {
       expect(result).to.equal("[false] [0] [] [not empty] ");
     });
 
-    it("should the number of interactions respect the limit", async () => {
+    it("should the number of interactions respect the limit even if the number of events is higher", async () => {
       const emitter = new EventEmitter();
 
       const iterator = forEmitOf<{ message: string }>(emitter, { limit: 10 });
@@ -410,6 +410,38 @@ describe("forEmitOf", () => {
       await sleep(0);
       expect(count).to.equal(10);
       expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] ")
+    });
+
+    it.only("should make all interactions if the value of limit is 0 ", async () => {
+      const emitter = new EventEmitter();
+
+      const iterator = forEmitOf<{ message: string }>(emitter, { limit: 0 });
+      let count = 0;
+      let result = "";
+      setTimeout(async () => {
+        emitter.emit("data", false);
+        emitter.emit("data", 0);
+        emitter.emit("data", "");
+        emitter.emit("data", "not empty");
+        emitter.emit("data", "not empty 2");
+        emitter.emit("data", "not empty 2");
+        emitter.emit("data", "not empty 3");
+        emitter.emit("data", "not empty 4");
+        emitter.emit("data", "not empty 5");
+        emitter.emit("data", "not empty 6");
+        emitter.emit("data", "not empty 7");
+        emitter.emit("end");
+      }, 10);
+
+
+      await sleep(10);
+      for await (const chunk of iterator) {
+        count++;
+        result += `[${chunk}] `;
+      }
+      await sleep(0);
+      expect(count).to.equal(11);
+      expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] [not empty 7] ")
     });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -443,5 +443,69 @@ describe("forEmitOf", () => {
       expect(count).to.equal(11);
       expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] [not empty 7] ")
     });
+
+    it("should the number of interactions respect the limit even if the number of events is higher", async () => {
+      const emitter = new EventEmitter();
+
+      const iterator = forEmitOf<{ message: string }>(emitter, { limit: 10 });
+      let count = 0;
+      let result = "";
+      setTimeout(async () => {
+        emitter.emit("data", false);
+        emitter.emit("data", 0);
+        emitter.emit("data", "");
+        emitter.emit("data", "not empty");
+        emitter.emit("data", "not empty 2");
+        emitter.emit("data", "not empty 2");
+        emitter.emit("data", "not empty 3");
+        emitter.emit("data", "not empty 4");
+        emitter.emit("data", "not empty 5");
+        emitter.emit("data", "not empty 6");
+        emitter.emit("data", "not empty 7");
+        emitter.emit("end");
+      }, 10);
+
+
+      await sleep(10);
+      for await (const chunk of iterator) {
+        count++;
+        result += `[${chunk}] `;
+      }
+      await sleep(0);
+      expect(count).to.equal(10);
+      expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] ")
+    });
+
+    it("should make all interactions if has no limit ", async () => {
+      const emitter = new EventEmitter();
+
+      const iterator = forEmitOf<{ message: string }>(emitter);
+      let count = 0;
+      let result = "";
+      setTimeout(async () => {
+        emitter.emit("data", false);
+        emitter.emit("data", 0);
+        emitter.emit("data", "");
+        emitter.emit("data", "not empty");
+        emitter.emit("data", "not empty 2");
+        emitter.emit("data", "not empty 2");
+        emitter.emit("data", "not empty 3");
+        emitter.emit("data", "not empty 4");
+        emitter.emit("data", "not empty 5");
+        emitter.emit("data", "not empty 6");
+        emitter.emit("data", "not empty 7");
+        emitter.emit("end");
+      }, 10);
+
+
+      await sleep(10);
+      for await (const chunk of iterator) {
+        count++;
+        result += `[${chunk}] `;
+      }
+      await sleep(0);
+      expect(count).to.equal(11);
+      expect(result).to.be.eqls("[false] [0] [] [not empty] [not empty 2] [not empty 2] [not empty 3] [not empty 4] [not empty 5] [not empty 6] [not empty 7] ")
+    });
   });
 });


### PR DESCRIPTION
Closes #4 
To control the limit of yield, I created a new option to the function forEmitOf that receives a new parameter called limit and use this parameter for controlling the flow.
I create a new flag that when the parameter is equal or higher than the limit ends up the iteration is set up as false than the while conditions is no fulfilled and ends up al the iterations and the events are closed, is important to say that when the limit value is 0 the behavior is the same as not sending the limit.