### PR TITLE
Keeping alive iterable with no timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .nyc_output/
 .vscode
+test.js

--- a/src/debugging.ts
+++ b/src/debugging.ts
@@ -41,3 +41,19 @@ export function debugKeepAlive<T = any>(
   }
   return countKeepAlive;
 }
+
+export function debugKeepAliveEnding<T = any>(
+  options: Options<T>,
+  countKeepAlive: number,
+  start: [number, number]
+) {
+  if (options.debug) {
+    const current = process.hrtime(start);
+    const seconds = current[0] + current[1] / 1e9;
+    console.log(
+      `Finishing keep alive control: ${countKeepAlive} keepalive cycles, ${seconds} secs, ${(
+        countKeepAlive / seconds
+      ).toFixed(2)} cycles per second`
+    );
+  }
+}

--- a/src/debugging.ts
+++ b/src/debugging.ts
@@ -1,0 +1,45 @@
+import { Options } from "./index";
+export function debugRaceEnd<T = any>(
+  options: Options<T>,
+  winner: symbol | void
+) {
+  if (options.debug) {
+    console.log(
+      `Finished response racing. Winner: ${String(winner) || "data emitting"}`
+    );
+  }
+}
+export function debugRaceStart<T = any>(options: Options<T>) {
+  if (options.debug) {
+    console.log(
+      "No more results to yield but emitter still active. Starting timeout race"
+    );
+  }
+}
+export function debugYieldLimit<T = any>(options: Options<T>) {
+  if (options.debug) {
+    console.log("Yielding limit reached! Stopping iterator");
+  }
+}
+export function debugYielding<T = any>(options: Options<T>, events: any[]) {
+  if (options.debug) {
+    console.log(`Results to yield: ${events.length}`);
+  }
+}
+export function debugKeepAlive<T = any>(
+  options: Options<T>,
+  countKeepAlive: number,
+  start: [number, number]
+) {
+  if (options.debug) {
+    countKeepAlive++;
+    const current = process.hrtime(start);
+    const seconds = current[0] + current[1] / 1e9;
+    console.log(
+      `${countKeepAlive} keepalive cycles, ${seconds} secs, ${(
+        countKeepAlive / seconds
+      ).toFixed(2)} cycles per second`
+    );
+  }
+  return countKeepAlive;
+}

--- a/src/debugging.ts
+++ b/src/debugging.ts
@@ -4,9 +4,7 @@ export function debugRaceEnd<T = any>(
   winner: symbol | void
 ) {
   if (options.debug) {
-    console.log(
-      `Finished response racing. Winner: ${String(winner) || "data emitting"}`
-    );
+    console.log(`Finished response racing. Winner: ${String(winner)}`);
   }
 }
 export function debugRaceStart<T = any>(options: Options<T>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ interface Options<T = any> {
    * this property defines the keepAlive time for such task. If timeout is used, this property is
    * ignored. Default: 1000
    */
-  idleInterval?: number;
+  keepAlive?: number;
 }
 
 type SuperEmitter = (EventEmitter | Readable | Writable) & {
@@ -200,9 +200,9 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
       function keepAlive() {
         setTimeout(() => {
           if (countEvents === 0 || options.inBetweenTimeout) {
-            setTimeout(keepAlive, options.idleInterval);
+            setTimeout(keepAlive, options.keepAlive);
           }
-        }, options.idleInterval);
+        }, options.keepAlive);
       }
       keepAlive();
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,11 +197,11 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
   emitter.on(options.event, eventListener);
   emitter.once(options.error, errorListener);
   options.end.forEach((event) => emitter.once(event, endListener));
+  const getRaceItems = raceFactory<T>(options, emitter);
 
   async function* generator() {
     let shouldYield = true;
     let countEvents = 0;
-    const getRaceItems = raceFactory<T>(options, emitter);
     if (!options.firstEventTimeout || !options.inBetweenTimeout) {
       keepAlive<T>(options, countEvents);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -199,7 +199,11 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
     if (!options.firstEventTimeout || !options.inBetweenTimeout) {
       function keepAlive() {
         setTimeout(() => {
-          if (countEvents === 0 || options.inBetweenTimeout) {
+          if (
+            active &&
+            !error &&
+            (countEvents === 0 || options.inBetweenTimeout)
+          ) {
             setTimeout(keepAlive, options.keepAlive);
           }
         }, options.keepAlive);
@@ -236,11 +240,12 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
 
         if (winner === timedOut) {
           removeListeners();
+          active = false;
           throw Error("Event timed out");
         }
       }
     }
-
+    active = false;
     removeListeners();
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ const defaults = {
   event: "data",
   error: "error",
   end: ["close", "end"],
-  idleInterval: 1000,
+  keepAlive: 1000,
 };
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,7 +197,7 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
   emitter.on(options.event, eventListener);
   emitter.once(options.error, errorListener);
   options.end.forEach((event) => emitter.once(event, endListener));
-  
+
   const getRaceItems = raceFactory<T>(options, emitter);
 
   async function* generator() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -202,7 +202,7 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
           if (
             active &&
             !error &&
-            (countEvents === 0 || options.inBetweenTimeout)
+            (countEvents === 0 || !options.inBetweenTimeout)
           ) {
             setTimeout(keepAlive, options.keepAlive);
           }

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ export interface Options<T = any> {
    * if some debug code lines will be printed. Useful to understand how for-emit-of are performing.
    * Default: false
    */
-  debug: boolean;
+  debug?: boolean;
 }
 
 type SuperEmitter = (EventEmitter | Readable | Writable) & {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
   debugYieldLimit,
   debugRaceStart,
   debugRaceEnd,
+  debugKeepAliveEnding,
 } from "./debugging";
 
 const defaults = {
@@ -220,6 +221,8 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
         ) {
           countKeepAlive = debugKeepAlive(options, countKeepAlive, start);
           setTimeout(keepAlive, options.keepAlive);
+        } else {
+          debugKeepAliveEnding(options, countKeepAlive, start);
         }
       }
       setTimeout(keepAlive, options.keepAlive);

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,7 @@ const defaults = {
   event: "data",
   error: "error",
   end: ["close", "end"],
-  keepAlive: 1000,
+  keepAlive: 0,
   debug: false,
 };
 
@@ -56,9 +56,9 @@ export interface Options<T = any> {
   limit?: number;
   /**
    * The max interval, in milliseconds, of idleness for the iterable generated. For the iterable
-   * to kept node process running, it need to have at least one task not based on event created,
+   * to kept node process running, it need to have at least one task not based on events created,
    * this property defines the keepAlive time for such task. If timeout is used, this property is
-   * ignored. Default: 1000
+   * ignored. If 0 is informed, the keepAlive is disabled. Default: 0
    */
   keepAlive?: number;
   /**
@@ -212,7 +212,10 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
     let countKeepAlive = 0;
     const start = process.hrtime();
 
-    if (!options.firstEventTimeout || !options.inBetweenTimeout) {
+    if (
+      options.keepAlive &&
+      (!options.firstEventTimeout || !options.inBetweenTimeout)
+    ) {
       function keepAlive() {
         if (
           active &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -197,6 +197,7 @@ function forEmitOf<T = any>(emitter: SuperEmitter, options?: Options<T>) {
   emitter.on(options.event, eventListener);
   emitter.once(options.error, errorListener);
   options.end.forEach((event) => emitter.once(event, endListener));
+  
   const getRaceItems = raceFactory<T>(options, emitter);
 
   async function* generator() {


### PR DESCRIPTION
Closes #7 

To keep the async iterable with no timeout alive, a setTimeout is done from time to time.
This setTimeout only happens if no timeout is specified, as the timeout mechanic is also enough to keep the process running.

Look that I did not create a test case for this problem as I couldn't figure out how to for two reasons:
* mocha is enough to keep node alive;
* The desired behavior I wanted here is for the process to never finish;