### PR TITLE
Performance improvement over fast iterables

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -682,6 +682,12 @@
         }
       }
     },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -2973,7 +2979,10 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -3655,7 +3664,10 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^5.0.0"
+          }
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,9 +64,9 @@
           }
         },
         "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         },
         "semver": {
@@ -142,9 +142,9 @@
       },
       "dependencies": {
         "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -312,9 +312,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -337,9 +337,9 @@
           "dev": true
         },
         "lodash": {
-          "version": "4.17.19",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-          "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
           "dev": true
         }
       }
@@ -681,12 +681,6 @@
           "dev": true
         }
       }
-    },
-    "ansi-regex": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "dev": true
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -1728,9 +1722,9 @@
       }
     },
     "glob-parent": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
-      "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
       "requires": {
         "is-glob": "^4.0.1"
@@ -1906,9 +1900,9 @@
       "dev": true
     },
     "ini": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "inquirer": {
@@ -1980,6 +1974,14 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^5.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.1",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+              "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+              "dev": true
+            }
           }
         },
         "supports-color": {
@@ -2386,9 +2388,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
     "lodash.flattendeep": {
@@ -2833,9 +2835,9 @@
       "dev": true
     },
     "normalize-url": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.0.tgz",
-      "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
+      "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
       "dev": true
     },
     "nyc": {
@@ -2971,10 +2973,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
+          "dev": true
         },
         "wrap-ansi": {
           "version": "6.2.0",
@@ -3181,9 +3180,9 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "path-to-regexp": {
@@ -3656,10 +3655,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
           "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^5.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -4169,9 +4165,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {

--- a/src/debugging.ts
+++ b/src/debugging.ts
@@ -1,3 +1,4 @@
+import { Queue } from "./queue";
 import { Options } from "./types";
 
 export function debugRaceEnd(options: Options, winner: symbol | void) {
@@ -20,7 +21,7 @@ export function debugYieldLimit(options: Options) {
   }
 }
 
-export function debugYielding(options: Options, events: any[]) {
+export function debugYielding(options: Options, events: Queue) {
   if (options.debug) {
     console.log(`Results to yield: ${events.length}`);
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -263,6 +263,13 @@ function forEmitOf<T = any>(
               return runReturn();
             }
             debugYielding(options, events);
+            if (!options.noSleep) {
+              /* We do not want to block the process!
+                This call allows other processes
+                a chance to execute.
+              */
+              await breath();
+            }
 
             const event = events.shift();
             countEvents++;
@@ -270,13 +277,6 @@ function forEmitOf<T = any>(
             if (options.limit && countEvents >= options.limit) {
               debugYieldLimit(options);
               shouldYield = false;
-            }
-            if (!options.noSleep) {
-              /* We do not want to block the process!
-                This call allows other processes
-                a chance to execute.
-              */
-              await breath();
             }
             return {
               done: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,6 +278,7 @@ function forEmitOf<T = any>(
               debugYieldLimit(options);
               shouldYield = false;
             }
+
             return {
               done: false,
               value: options.transform ? options.transform(event) : event,

--- a/src/index.ts
+++ b/src/index.ts
@@ -184,7 +184,7 @@ function forEmitOf<T = any>(
     error = err;
   };
   const removeListeners = () => {
-    events = getQueue<T>();
+    events = getQueue();
     emitter.removeListener(options.event, eventListener);
     emitter.removeListener(options.error, errorListener);
     options.end.forEach((event) => emitter.removeListener(event, endListener));

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "events";
-import { sleep } from "./sleep";
+import { breath } from "./sleep";
 import { timedOut, timeout } from "./timeout";
 import {
   debugKeepAlive,
@@ -271,15 +271,17 @@ function forEmitOf<T = any>(
               debugYieldLimit(options);
               shouldYield = false;
             }
-            const result = {
+            if (!options.noSleep) {
+              /* We do not want to block the process!
+                This call allows other processes
+                a chance to execute.
+              */
+              await breath();
+            }
+            return {
               done: false,
               value: options.transform ? options.transform(event) : event,
             };
-            return options.noSleep
-              ? result
-              : new Promise<any>((resolve) =>
-                  setImmediate(() => resolve(result))
-                );
           },
           return: runReturn,
         };

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -1,0 +1,38 @@
+interface Node<T> {
+  value: T;
+  next?: Node<T>;
+}
+
+export interface Queue<T = any> {
+  length: number;
+  shift(): T | undefined;
+  push(value: T): void;
+}
+
+export function getQueue<T = any>(): Queue<T> {
+  let first: Node<T> | undefined;
+  let last: Node<T> | undefined;
+  return {
+    length: 0,
+    shift() {
+      if (first) {
+        const { value } = first;
+        first = first.next;
+        if (!first) {
+          last = first;
+        }
+        this.length--;
+        return value;
+      }
+    },
+    push(value: T) {
+      const node = { value };
+      if (!last) {
+        first = last = node;
+      } else {
+        last = last.next = node;
+      }
+      this.length++;
+    },
+  };
+}

--- a/src/sleep.ts
+++ b/src/sleep.ts
@@ -1,2 +1,3 @@
 import * as util from "util";
 export const sleep = util.promisify(setTimeout);
+export const breath = util.promisify(setImmediate);

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,7 +49,10 @@ export interface Options<T = any> {
    */
   debug?: boolean;
   /**
-   * Disable sleeping between iterations
+   * Disable sleeping between iterations. Warning! Enabling this option can make the iteration block
+   * the event loop, depending of what you do in each operation. Use that only if you know what you're
+   * doing or is not a issue for you that other processes doesn't step forward while your forEmitOf
+   *  iterable is being iterated.
    */
   noSleep?: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,10 @@ export interface Options<T = any> {
    * Default: false
    */
   debug?: boolean;
+  /**
+   * Disable sleeping between iterations
+   */
+  noSleep?: boolean;
 }
 
 export interface Context {

--- a/test/benchmark.test.ts
+++ b/test/benchmark.test.ts
@@ -1,0 +1,50 @@
+import { expect } from "chai";
+import { createReadStream } from "fs";
+import readline = require("readline");
+import forEmitOf = require("../src");
+
+const MICROSECOND_SCALE = 1000000;
+describe("benchmarking", () => {
+  it("should perform well with noSleep as false", async () => {
+    const start = Date.now();
+    const rl = readline.createInterface({
+      input: createReadStream("test/big.txt"),
+    });
+    const iterable = forEmitOf(rl, {
+      event: "line",
+      noSleep: false,
+    });
+
+    let i = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const line of iterable) {
+      i += 1;
+    }
+    const end = Date.now();
+
+    expect(((end - start) * MICROSECOND_SCALE) / i).to.be.lessThan(
+      MICROSECOND_SCALE / 100
+    );
+  });
+  it("should perform well with noSleep as true", async () => {
+    const start = Date.now();
+    const rl = readline.createInterface({
+      input: createReadStream("test/big.txt"),
+    });
+    const iterable = forEmitOf(rl, {
+      event: "line",
+      noSleep: false,
+    });
+
+    let i = 0;
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    for await (const line of iterable) {
+      i += 1;
+    }
+    const end = Date.now();
+
+    expect(((end - start) * MICROSECOND_SCALE) / i).to.be.lessThan(
+      MICROSECOND_SCALE / 100
+    );
+  });
+});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -611,7 +611,7 @@ describe("forEmitOf", () => {
         }
       }
 
-      expect(debugging.debugYielding).to.have.been.calledTwice;
+      expect(debugging.debugYielding).to.have.been.calledOnce;
       expect(debugging.debugIteratorReturn).to.have.been.called;
       expect(result).to.be.eq("[1] [2] ");
       expect(counter).to.be.eq(2);

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -404,6 +404,36 @@ describe("forEmitOf", () => {
       );
     });
 
+    it("event processing must be blocking when noSleep is true", async () => {
+      const emitter = new EventEmitter();
+
+      const iterator = forEmitOf<{ message: string }>(emitter, {
+        noSleep: true,
+      });
+
+      let result = "";
+      setTimeout(async () => {
+        emitter.emit("data", { message: "test1" });
+        emitter.emit("data", { message: "test2" });
+        emitter.emit("data", { message: "test3" });
+        emitter.emit("data", { message: "test4" });
+        emitter.emit("end");
+      }, 10);
+
+      await sleep(10);
+      for await (const chunk of iterator) {
+        setImmediate(async () => {
+          result += ` ${chunk.message}a `;
+        });
+        result += chunk.message;
+      }
+      await sleep(0);
+
+      expect(result).to.equal(
+        "test1test2test3test4 test1a  test2a  test3a  test4a "
+      );
+    });
+
     it("event processing must emit even falsy values", async () => {
       const emitter = new EventEmitter();
 


### PR DESCRIPTION
Solves #23 

Some performance improvements were implemented in this PR.

* The events array now is a queue instance. A simple implementation was made in code, which will give a performance of **O(1)** for the dequeuing operation, opposed to the previous **O(N)** of destructuring an array;
* Trick deactivating and activating event listening to make waitResponse better. If waitResponse already gets a valid value to return, this value will not be included in the queue (as the listeners that do so are off) and can be yielded immediately. Just after getting the value, the original listener (that adds to the queue) is re-enabled, so there's no risk any message is lost;
* the sleep call was replaced by a promise generated from a setImmediate. This will give the same effect (making a non blocking operation), but will hang on much less, greatly increasing performance over a large amount of events;
* A no sleep option was created for the cases where the lib user doesn't care if a blocking operation is done, but cares about performance (for example, when we're creating a cli);

I also added a new test suite to validate performance, using a large file as the source of event emitting. This suite doesn't pass on the previous version, but I don't know how long it would take to finish because it timed out in 100 seconds. I think it would take 5 to 10 minutes to finish.
Using this branch locally the test finished in 386 ms with noSleep = false and 349ms with noSleep = true.

Running a separated benchmark without all the mocha overload I got the following results, but over a file with only 9074 lines:
```
before

####################################################
WARMUP: Current memory usage: 2.2 MB
WARMUP: readline forEmitOf profiling started
Read 9074 lines
WARMUP: readline forEmitOf profiling finished in 10757ms
WARMUP: Current memory usage (before GC): 15.15 MB
WARMUP: Current memory usage (after GC): 2.39 MB

####################################################
RUN 1: readline forEmitOf profiling started
Read 9074 lines
RUN 1: readline forEmitOf profiling finished in 10805ms
RUN 1: Current memory usage (before GC): 11.14 MB
RUN 1: Current memory usage (after GC): 2.39 MB

####################################################
RUN 2: readline forEmitOf profiling started
Read 9074 lines
RUN 2: readline forEmitOf profiling finished in 10798ms
RUN 2: Current memory usage (before GC): 11.91 MB
RUN 2: Current memory usage (after GC): 2.4 MB

####################################################
RUN 3: readline forEmitOf profiling started
Read 9074 lines
RUN 3: readline forEmitOf profiling finished in 10849ms
RUN 3: Current memory usage (before GC): 14.5 MB
RUN 3: Current memory usage (after GC): 2.66 MB

after

####################################################
WARMUP: Current memory usage: 2.21 MB
WARMUP: readline forEmitOf profiling started
Read 9074 lines
WARMUP: readline forEmitOf profiling finished in 56ms
WARMUP: Current memory usage (before GC): 4.21 MB
WARMUP: Current memory usage (after GC): 2.35 MB

####################################################
RUN 1: readline forEmitOf profiling started
Read 9074 lines
RUN 1: readline forEmitOf profiling finished in 47ms
RUN 1: Current memory usage (before GC): 6.75 MB
RUN 1: Current memory usage (after GC): 2.62 MB

####################################################
RUN 2: readline forEmitOf profiling started
Read 9074 lines
RUN 2: readline forEmitOf profiling finished in 52ms
RUN 2: Current memory usage (before GC): 6.32 MB
RUN 2: Current memory usage (after GC): 2.63 MB

####################################################
RUN 3: readline forEmitOf profiling started
Read 9074 lines
RUN 3: readline forEmitOf profiling finished in 46ms
RUN 3: Current memory usage (before GC): 4.8 MB
RUN 3: Current memory usage (after GC): 2.64 MB

after with noSleep

####################################################
WARMUP: Current memory usage: 2.21 MB
WARMUP: readline forEmitOf profiling started
Read 9074 lines
WARMUP: readline forEmitOf profiling finished in 23ms
WARMUP: Current memory usage (before GC): 3.39 MB
WARMUP: Current memory usage (after GC): 2.33 MB

####################################################
RUN 1: readline forEmitOf profiling started
Read 9074 lines
RUN 1: readline forEmitOf profiling finished in 16ms
RUN 1: Current memory usage (before GC): 4.38 MB
RUN 1: Current memory usage (after GC): 2.35 MB

####################################################
RUN 2: readline forEmitOf profiling started
Read 9074 lines
RUN 2: readline forEmitOf profiling finished in 14ms
RUN 2: Current memory usage (before GC): 4.18 MB
RUN 2: Current memory usage (after GC): 2.38 MB

####################################################
RUN 3: readline forEmitOf profiling started
Read 9074 lines
RUN 3: readline forEmitOf profiling finished in 16ms
RUN 3: Current memory usage (before GC): 4.21 MB
RUN 3: Current memory usage (after GC): 2.37 MB
```